### PR TITLE
Indexing support and optimizations

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -45,7 +45,7 @@ julia> length(list)
 3
 
 julia> collect(list)
-3-element Array{Int64,1}:
+3-element Vector{Int64}:
  1
  2
  3
@@ -67,7 +67,7 @@ julia> length(list)
 2
 
 julia> collect(list)
-2-element Array{Int64,1}:
+2-element Vector{Int64}:
  1
  3
 ```
@@ -86,4 +86,17 @@ julia> 1 ∈ list
 true
 ```
 
+**Random access:** read or modify the `i`th element using indexing operations:
+
+```jldoctest; setup = :(using SkipLists)
+julia> list = SkipList{Int64}();
+
+julia> insert!(list, 4); insert!(list, 2); insert!(list, 3); 
+
+julia> list[2]
+3
+
+julia> collect(list) == [list[i] for i=1:length(list)] == 2:4
+true
+```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -86,7 +86,7 @@ julia> 1 ∈ list
 true
 ```
 
-**Random access:** read or modify the `i`th element using indexing operations:
+**Random access:** read the `i`th element using indexing operations:
 
 ```jldoctest; setup = :(using SkipLists)
 julia> list = SkipList{Int64}();

--- a/src/core.jl
+++ b/src/core.jl
@@ -25,7 +25,7 @@ Abstract typedefs
 ===========================#
 
 abstract type AbstractNode{T,M} end
-abstract type AbstractSkipList{T,M} end
+abstract type AbstractSkipList{T,M} <: AbstractVector{T} end
 
 abstract type LeftSentinel{T,M} end
 abstract type RightSentinel{T,M} end

--- a/src/list.jl
+++ b/src/list.jl
@@ -27,7 +27,7 @@ julia> list = SkipList{Int64}();
 julia> insert!(list, 1); insert!(list, 2); insert!(list, 3);
 
 julia> collect(list)
-3-element Array{Int64,1}:
+3-element Vector{Int64}:
  1
  2
  3
@@ -49,17 +49,15 @@ mutable struct SkipList{T,M} <: AbstractSkipList{T,M}
     # function
     predecessor_buffer::Vector{Node{T,M}}
     successor_buffer::Vector{Node{T,M}}
+    predecessor_offset_buffer::Vector{Int}
 
     # left / right sentinel nodes marking the left and right ends of the skip list
     left_sentinel::Node{T,M}
     right_sentinel::Node{T,M}
 
-    # The height of the skip list. This should be an upper bound on the height of all
-    # nodes within the skip list
+    # The height of the skip list. 
+    # This is one more than the height of the highest non-sentinel node.
     height::Int64
-
-    # The number of elements in the skip list
-    length::Int64
 end
 
 """
@@ -68,7 +66,7 @@ end
 A non-concurrent skip list that only allows one copy of each key. `SkipListSet{T}` is an alias for
 `SkipList{T,:Set}`.
 """
-SkipListSet{T} = SkipList{T,:Set}
+const SkipListSet{T} = SkipList{T,:Set}
 
 #===========================
 Shared constructors

--- a/src/list_nonconcurrent.jl
+++ b/src/list_nonconcurrent.jl
@@ -264,4 +264,13 @@ function interpolate_node!(list, node, predecessors, successors, predecessor_off
     end
 end
 
+function collect_nodes(skiplist)
+    current = skiplist.left_sentinel
+    res = [current]
+    while current !== skiplist.right_sentinel
+        current = next(current, 1)
+        push!(res, current)
+    end
+    res
+end
 

--- a/src/node.jl
+++ b/src/node.jl
@@ -14,6 +14,7 @@ Type definitions
 struct Node{T,M} <: AbstractNode{T,M}
     vals::Vector{T}
     next::Vector{Node{T,M}}
+    width::Vector{Int}
     capacity::Int64
     flags::UInt8
 end

--- a/src/node_nonconcurrent.jl
+++ b/src/node_nonconcurrent.jl
@@ -33,8 +33,14 @@ Node external API
 ===========================#
 
 function Base.string(node::Node)
-    result = "$(node.vals), height = $(height(node))"
-    "Node($result)"
+    if is_left_sentinel(node)
+        "<left sentinel>"
+    elseif is_right_sentinel(node)
+        "<right sentinel>"
+    else
+        result = "$(node.vals), height = $(height(node))"
+        "Node($result)"
+    end
 end
 
 Base.length(node::Node) = length(node.vals)
@@ -46,38 +52,6 @@ Base.isempty(node::Node) = (length(node) == 0)
 isfull(node::Node) = is_sentinel(node) || (length(node) == capacity(node))
 
 Base.in(val, node::Node) = insorted(val, node.vals)
-
-@generated function Base.insert!(node::Node{T,M}, val) where {T,M}
-    quote
-        if length(node) ≥ capacity(node)
-            "Node size exceeds capacity ($(capacity(node)))" |>
-            ErrorException |>
-            throw
-        end
-
-        idx = searchsorted(node.vals, val)
-
-        $(
-            if M == :Set
-                quote
-                    if first(idx) > last(idx)     # Value not found in node
-                        insert!(node.vals, first(idx), val)
-                    end
-                end
-            else
-                quote
-                    insert!(node.vals, first(idx), val)
-                end
-            end
-        )
-    end
-end
-
-Base.delete!(node::Node, val) =
-    searchsorted(node.vals, val) |>
-    idx -> if first(idx) ≤ last(idx)
-        deleteat!(node.vals, first(idx))
-    end
 
 function split!(node::Node{T,M}; kws...) where {T,M}
     median_idx = div(length(node), 2)

--- a/src/node_nonconcurrent.jl
+++ b/src/node_nonconcurrent.jl
@@ -18,7 +18,8 @@ function Node{T,M}(
 
     height = min(height, max_height)
     next = Vector{Node{T,M}}(undef, height)
-    Node{T,M}(vals, next, capacity, flags)
+    width = fill(length(vals), height)
+    Node{T,M}(vals, next, width, capacity, flags)
 end
 
 LeftSentinel{T,M}(; max_height = DEFAULT_MAX_HEIGHT, kws...) where {T,M} =
@@ -44,9 +45,7 @@ capacity(node::Node) = node.capacity
 Base.isempty(node::Node) = (length(node) == 0)
 isfull(node::Node) = is_sentinel(node) || (length(node) == capacity(node))
 
-Base.in(val, node::Node) =
-    searchsorted(node.vals, val) |>
-    idx -> first(idx) ≤ last(idx)
+Base.in(val, node::Node) = insorted(val, node.vals)
 
 @generated function Base.insert!(node::Node{T,M}, val) where {T,M}
     quote
@@ -84,16 +83,6 @@ function split!(node::Node{T,M}; kws...) where {T,M}
     median_idx = div(length(node), 2)
     right_vals = splice!(node.vals, median_idx+1:length(node))
     node, Node{T,M}(right_vals; kws...)
-end
-
-"""
-Insert a new node between a list of predecessor and successor nodes
-"""
-function interpolate_node!(predecessors, successors, node)
-    for level = 1:height(node)
-        link_nodes!(predecessors[level], node, level)
-        link_nodes!(node, successors[level], level)
-    end
 end
 
 

--- a/test/test_node_nonconcurrent.jl
+++ b/test/test_node_nonconcurrent.jl
@@ -30,29 +30,6 @@ using SkipLists: Node, LeftSentinel, RightSentinel
         @test SkipLists.is_right_sentinel(rsentinel)
     end
 
-    @testset "Insert and delete from Node" begin
-        node = Node{:List}(1:2:50; capacity=100)
-
-        success = true
-        for ii = shuffle(2:2:50)
-            insert!(node, ii)
-            success = success && ii ∈ node
-        end
-        @test success
-
-        success = true
-        for ii = shuffle(1:2:50)
-            delete!(node, ii)
-            success = success && ii ∉ node
-        end
-        @test success
-
-        # If we attempt to insert into a node past its capacity, we should
-        # get an error
-        node = Node{:List}(1:10; capacity=10)
-        @test SkipLists.isfull(node)
-        @test_throws ErrorException insert!(node, 11)
-    end
 
     @testset "Split Node" begin
         node = Node{:List}(1:10)

--- a/test/test_node_nonconcurrent.jl
+++ b/test/test_node_nonconcurrent.jl
@@ -66,8 +66,8 @@ using SkipLists: Node, LeftSentinel, RightSentinel
     @testset "Compare nodes" begin
         lsentinel = LeftSentinel{Int64,:List}()
         rsentinel = RightSentinel{Int64,:List}()
-        node_1 = Node{Int64}([0])
-        node_2 = Node{Int64}(1:10)
+        node_1 = Node{:List}([0])
+        node_2 = Node{:List}(1:10)
 
         @test lsentinel < node_1     && lsentinel ≤ node_1
         @test node_1 < node_2        && node_1 ≤ node_2
@@ -76,8 +76,8 @@ using SkipLists: Node, LeftSentinel, RightSentinel
         @test lsentinel ≤ lsentinel && !(lsentinel < lsentinel)
         @test rsentinel ≤ rsentinel && !(rsentinel < rsentinel)
 
-        @test 0 == node_1 == Node{Int64}(0:5:10) == 0
-        @test 1 == node_2 == Node{Int64}([1]) == 1
+        @test 0 == node_1 == Node{:List}(0:5:10) == 0
+        @test 1 == node_2 == Node{:List}([1]) == 1
     end
 end
 


### PR DESCRIPTION
This PR:
 - adds O(log(n)) indexing support to `SkipLists` (i.e., accessing the `i`th smallest element) (I'm using this to implement fast running median with correct NaN handling).
 - optimizes by avoiding the double call to `searchsorted` in insertion and deletion (once to find the correct node, and again to insert/delete in the node).

Result of the `benchmark_generate_skiplist` benchmark from `benchmark/benchmark_generation.jl`:
- version 1.1.0:
```
 BenchmarkTools.Trial: 73 samples with 1 evaluation.
 Range (min … max):  50.266 ms … 83.954 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     58.545 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   58.636 ms ±  4.699 ms  ┊ GC (mean ± σ):  1.03% ± 2.36%

             ▂    ▂  ▅   ▂ ▅  ▅  █ ▂     ▂▂
  ▅▁▁▅▁▁▁█▅▅▁█▅██▅██▅█▁▅▁███▁▁█▅▅█▅██▁█▅▅████▁█▁█▅▁▁▁▁▁▁▁▁▁▁▅ ▁
  50.3 ms         Histogram: frequency by time        67.7 ms <

 Memory estimate: 6.34 MiB, allocs estimate: 1597.
```
- this PR:
```
BenchmarkTools.Trial: 109 samples with 1 evaluation.
 Range (min … max):  31.594 ms … 51.328 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     35.377 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   36.026 ms ±  2.934 ms  ┊ GC (mean ± σ):  1.83% ± 3.98%

       ▃  █ ▅▃  ▂▂▂
  ▃▁▁▅▆█▆▇█▇██▆▇███▁▃▇█▃▁▇▇▁▃▃▇▃▃▃▅▁▁▁▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃ ▃
  31.6 ms         Histogram: frequency by time        48.5 ms <

 Memory estimate: 6.35 MiB, allocs estimate: 2107.
```