### PR TITLE
bugfix: BoundsError on insertion

### DIFF
--- a/src/list_nonconcurrent.jl
+++ b/src/list_nonconcurrent.jl
@@ -82,6 +82,13 @@ function Base.insert!(list::SkipList{T,M}, val) where {T,M}
                 capacity=node_capacity(list),
                 p=height_p(list),
             )
+            
+            # Correct the insertion point if necessary to account for the split
+            @assert insertion_node === old_node
+            if insertion_index > length(old_node)
+                insertion_node = new_node
+                insertion_index -= length(old_node)
+            end
 
             # Fix node widths to account for elements removed from `old_node`
             # (`new_node` is still not in the list)
@@ -109,14 +116,6 @@ function Base.insert!(list::SkipList{T,M}, val) where {T,M}
 
             # Insert the new node between the predecessor / successor nodes.
             interpolate_node!(list, new_node, predecessors, successors, predecessor_offsets)
-
-            # We insert into the right node if its key is ≤ the insertion value;
-            # otherwise, we insert into the left node.
-            @assert insertion_node === old_node
-            if is_sentinel(old_node) || new_node ≤ val
-                insertion_node = new_node
-                insertion_index -= length(old_node)
-            end
         end
 
         insert!(insertion_node.vals, insertion_index, val)

--- a/test/list_test_utils.jl
+++ b/test/list_test_utils.jl
@@ -108,7 +108,86 @@ end
             @test result_success
             invariant_tests(list)
         end
+
+        @testset "Insert random floats" for n = [20, 1000, 100_000]
+            vals = rand(n)
+            vals_sorted = sort(vals)
+
+            list = $L{Float64}()
+            result_success = true
+            for x in vals
+                result = insert!(list, x)
+                result_success = result_success && (result == Some(x))
+            end
+            
+            @test collect(list) == vals_sorted
+            @test collect(list) isa Vector{Float64}
+            @test length(list) == n
+            @test result_success
+            invariant_tests(list)
+
+            insert!(list, -1)
+
+            @test length(list) == n+1
+            @test collect(list) == [-1; vals_sorted]
+            invariant_tests(list)
+
+            # Insert sorted values
+            list = $L{Float64}()
+            result_success = true
+            for x in vals_sorted
+                result = insert!(list, x)
+                result_success = result_success && (result == Some(x))
+            end
+
+            @test collect(list) == vals_sorted
+            @test collect(list) isa Vector{Float64}
+            @test length(list) == n
+            @test result_success
+            invariant_tests(list)
+        end
+
+        @testset "Insert with many duplicates" for node_capacity in [20, 1000, 100_000]
+            # vals with many duplicates, each value count exceeding node capacity
+            n = 10 * node_capacity
+            vals = rand(-1:1, n)
+            vals_sorted = sort(vals)
+
+            list = $L{Float64}(; node_capacity)
+            result_success = true
+            for x in vals
+                result = insert!(list, x)
+                result_success = result_success && (result == Some(x))
+            end
+            
+            @test collect(list) == vals_sorted
+            @test collect(list) isa Vector{Float64}
+            @test length(list) == n
+            @test result_success
+            invariant_tests(list)
+
+            insert!(list, -10)
+
+            @test length(list) == n+1
+            @test collect(list) == [-10; vals_sorted]
+            invariant_tests(list)
+
+            # Insert sorted values
+            list = $L{Float64}(; node_capacity)
+            result_success = true
+            for x in vals_sorted
+                result = insert!(list, x)
+                result_success = result_success && (result == Some(x))
+            end
+
+            @test collect(list) == vals_sorted
+            @test collect(list) isa Vector{Float64}
+            @test length(list) == n
+            @test result_success
+            invariant_tests(list)
+        end
     end
+
 end
 
 @generated function test_iterate_over_list(::Type{L}) where {L <: AbstractSkipList}


### PR DESCRIPTION
Fixes a `BoundsError` on insertion that occurs if a full node is split inside a run of equal values.
This occurs in the example in the new test here ("Insert with many duplicates").